### PR TITLE
Enable this gem to be used with Rails versions prior to 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in saasu2.gemspec
 gemspec
+
+# make rails 4+ deep hash functions available to rails <4
+gem 'deep_hash_transform', :git => "https://github.com/basecamp/deep_hash_transform"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ And then execute:
 Create an initializer file with your Saasu configuration eg config/initilizers/saasu.rb
 ```ruby
 require 'saasu'
+require 'deep_hash_transform' #required if using Rails <4
 
 Saasu::Config.configure do |c|
   c.username = 'username@email.com'

--- a/saasu2.gemspec
+++ b/saasu2.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "webmock"
   spec.add_dependency 'activesupport'
+  # make rails 4+ deep hash functions available to rails <4
+  spec.add_dependency 'deep_hash_transform'
 end


### PR DESCRIPTION
This gem uses Hash.deep_hash_transform which is only available if using Rails 4+. basecamp have backported these functions, so add their gem as a dependency